### PR TITLE
Add parsing to auto add / for MFS paths

### DIFF
--- a/src/objectManager.js
+++ b/src/objectManager.js
@@ -213,9 +213,8 @@ class ObjectManager {
           }
           const task = (async () => {
             await queue.add(async () => {
-              const mfsPath = entry.path.startsWith('/') ? entry.path : `/${entry.path}`;
               uploadLogger.silly("SOURCE_IMPORT_STARTED", {
-                path: mfsPath,
+                path: entry.path,
                 size: queue.size,
               });
 
@@ -249,9 +248,9 @@ class ObjectManager {
                 } else {
                   return;
                 }
-                createdFiles.set(mfsPath, createdFile);
+                createdFiles.set(entry.path, createdFile);
                 uploadLogger.verbose("SOURCE_IMPORT_COMPLETED", {
-                  path: mfsPath,
+                  path: entry.path,
                   size: queue.size,
                 });
               } else {
@@ -263,9 +262,9 @@ class ObjectManager {
                 } else {
                   return;
                 }
-                createdFiles.set(mfsPath, createdFile);
+                createdFiles.set(entry.path, createdFile);
                 uploadLogger.verbose("SOURCE_IMPORT_COMPLETED", {
-                  path: mfsPath,
+                  path: entry.path,
                   size: queue.size,
                 });
               }

--- a/src/objectManager.js
+++ b/src/objectManager.js
@@ -133,7 +133,7 @@ class ObjectManager {
    * // Upload Directory
    * await objectManager.upload("my-first-directory", [
    *  {
-   *   path: "/testObjects/1.txt",
+   *   path: "/testObjects/1.txt",  // Virtual Path to store contents at within IPFS Folder/Directory
    *   content: Buffer.from("upload test object", "utf-8"),
    *  },
    *  {
@@ -212,8 +212,9 @@ class ObjectManager {
           }
           const task = (async () => {
             await queue.add(async () => {
+              const mfsPath = entry.path.startsWith('/') ? entry.path : `/${entry.path}`;
               uploadLogger.silly("SOURCE_IMPORT_STARTED", {
-                path: entry.path,
+                path: mfsPath,
                 size: queue.size,
               });
 
@@ -247,9 +248,9 @@ class ObjectManager {
                 } else {
                   return;
                 }
-                createdFiles.set(entry.path, createdFile);
+                createdFiles.set(mfsPath, createdFile);
                 uploadLogger.verbose("SOURCE_IMPORT_COMPLETED", {
-                  path: entry.path,
+                  path: mfsPath,
                   size: queue.size,
                 });
               } else {
@@ -261,9 +262,9 @@ class ObjectManager {
                 } else {
                   return;
                 }
-                createdFiles.set(entry.path, createdFile);
+                createdFiles.set(mfsPath, createdFile);
                 uploadLogger.verbose("SOURCE_IMPORT_COMPLETED", {
-                  path: entry.path,
+                  path: mfsPath,
                   size: queue.size,
                 });
               }

--- a/src/objectManager.js
+++ b/src/objectManager.js
@@ -206,7 +206,8 @@ class ObjectManager {
         });
         let createFilePromises = [];
         const queue = new PQueue({ concurrency: 50 });
-        for (const entry of source) {
+        for (let entry of source) {
+          entry.path = entry.path.startsWith("/") ? entry.path : `/${entry.path}`;
           if (entry.content === null) {
             continue;
           }

--- a/test/objectManager.spec.cjs
+++ b/test/objectManager.spec.cjs
@@ -157,6 +157,38 @@ test("upload directory", async () => {
   }
 });
 
+test("upload directory relative paths", async () => {
+  // Create Bucket `create-object-test-pass
+  const uploadDirectoryTestBucket = `${TEST_PREFIX}-create-directory-relative-test-pass`;
+  await createBucket(uploadDirectoryTestBucket);
+
+  try {
+    // Upload object `create-object-test`
+    const uploaded = await uploadObject(
+      uploadDirectoryTestBucket,
+      `create-directory-relative-test`,
+      [
+        {
+          path: "testObjects/1.txt",
+          content: Buffer.from("upload test object", "utf-8"),
+        },
+        {
+          path: "testObjects/deep/1.txt",
+          content: Buffer.from("upload deep test object", "utf-8"),
+        },
+        {
+          path: "topLevel.txt",
+          content: Buffer.from("upload top level test object", "utf-8"),
+        },
+      ],
+    );
+    assert.strictEqual(uploaded, true);
+    await deleteObject(uploadDirectoryTestBucket, `create-directory-relative-test`);
+  } finally {
+    await deleteBucket(uploadDirectoryTestBucket);
+  }
+});
+
 test("download object", async () => {
   // Create bucket `download-object-test-pass`
   const downloadTestBucket = `${TEST_PREFIX}-download-object-test-pass`;


### PR DESCRIPTION
Fixes #9 by automatically adding a slash to file paths.
Adds better explanation to documentation that path is the virtual path within the IPFS folder